### PR TITLE
remove xlocale

### DIFF
--- a/camb/src/common/base_cpp/locale_guard.h
+++ b/camb/src/common/base_cpp/locale_guard.h
@@ -17,7 +17,7 @@
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <locale.h>
-#include <xlocale.h>
+//#include <xlocale.h>
 #endif
 
 namespace indigo


### PR DESCRIPTION
remove xlocale in header which is no longer included with glibc (based on a quick search) to enable compilation on current operating systems